### PR TITLE
Last marker bug

### DIFF
--- a/lib/antlr3/tree.rb
+++ b/lib/antlr3/tree.rb
@@ -980,7 +980,7 @@ class CommonTreeNodeStream
   include TreeNodeStream
   
   attr_accessor :token_stream
-  attr_reader :adaptor, :position
+  attr_reader :adaptor, :position, :last_marker
   
   def initialize( *args )
     options = args.last.is_a?( ::Hash ) ? args.pop : {}


### PR DESCRIPTION
Hi,

this is a small patch for a bug that shows up in our grammar. Some part of the code expects last_marker to be readable and I simply added the variable to the attr_reader list.

Cheers
